### PR TITLE
Laravel 11 & 12 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea
+.vscode
+.phpunit.cache
+.phpunit.result.cache
+vendor
+composer.lock

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SPYLWZ8Y5E4
 
 ## Requirements
 
-* Laravel: 6.0 and up
-* PHP: 7.1 and newer
+* Laravel: 9.0 and up
+* PHP: 8.1 and newer
 
 #### Database schema
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SPYLWZ8Y5E4
 
 ## Requirements
 
-* Laravel: 9.0 and up
-* PHP: 8.1 and newer
+* Laravel: 11.0 and up
+* PHP: 8.2 and newer
 
 #### Database schema
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "laravel/framework": "^9.0 || ^10.0"
+    "laravel/framework": "^9.0 || ^10.0 || ^11.0"
   },
   "require-dev": {
     "laravel/pint": "^1.6"

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,8 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
-    "laravel/framework": "^9.0 || ^10.0 || ^11.0"
+    "php": "^8.2",
+    "laravel/framework": "^11.0 || ^12.0"
   },
   "require-dev": {
     "laravel/pint": "^1.6"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,10 @@
   ],
   "require": {
     "php": ">=8.0",
-    "laravel/framework": "^9.0"
+    "laravel/framework": "^9.0 || ^10.0"
+  },
+  "require-dev": {
+    "laravel/pint": "^1.5"
   },
   "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "laravel/framework": "^9.0 || ^10.0"
   },
   "require-dev": {
-    "laravel/pint": "^1.5"
+    "laravel/pint": "^1.6"
   },
   "minimum-stability": "stable"
 }

--- a/src/Traits/EncryptableDbAttribute.php
+++ b/src/Traits/EncryptableDbAttribute.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Crypt;
 
 /**
  * Trait EncryptableDbAttribute
- * @package betterApp\LaravelDbEncrypter\Traits
  */
 trait EncryptableDbAttribute
 {
@@ -24,7 +23,7 @@ trait EncryptableDbAttribute
         }
 
         // decrypt value before casts
-        if (!is_null($value) && $value !== '' && in_array($key, $this->encryptable)) {
+        if (! is_null($value) && $value !== '' && in_array($key, $this->encryptable)) {
             $value = $this->decrypt($value);
         }
 
@@ -145,14 +144,10 @@ trait EncryptableDbAttribute
         return $attributes;
     }
 
-    /**
-     * @param array $attributes
-     * @return array
-     */
     private function decryptAttributes(array $attributes): array
     {
         foreach ($attributes as $key => $value) {
-            if (!in_array($key, $this->encryptable) || is_null($value) || $value === '') {
+            if (! in_array($key, $this->encryptable) || is_null($value) || $value === '') {
                 continue;
             }
 
@@ -163,29 +158,29 @@ trait EncryptableDbAttribute
     }
 
     /**
-     * @param mixed $value
-     *
+     * @param  mixed  $value
      * @return mixed
      */
     private function encrypt($value)
     {
         try {
             $value = Crypt::encrypt($value);
-        } catch (EncryptException $e) {}
+        } catch (EncryptException $e) {
+        }
 
         return $value;
     }
 
     /**
-     * @param mixed $value
-     *
+     * @param  mixed  $value
      * @return mixed
      */
     private function decrypt($value)
     {
         try {
             $value = Crypt::decrypt($value);
-        } catch (DecryptException $e) {}
+        } catch (DecryptException $e) {
+        }
 
         return $value;
     }


### PR DESCRIPTION
This pull request includes several updates to improve compatibility with newer versions of Laravel and PHP, as well as some code cleanup in the `EncryptableDbAttribute` trait. Below are the most important changes:

### Compatibility Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R19): Updated the requirements to Laravel 11.0 and PHP 8.2.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L41-R45): Updated dependencies to require PHP 8.2 and Laravel framework versions 11.0 or 12.0. Added `laravel/pint` as a development dependency.

### Code Cleanup:
* [`src/Traits/EncryptableDbAttribute.php`](diffhunk://#diff-991a58c19c5359b1298f712e10055ced99496c5d9091b4a577d6e511f9487b42L11): Removed an unnecessary package comment.
* [`src/Traits/EncryptableDbAttribute.php`](diffhunk://#diff-991a58c19c5359b1298f712e10055ced99496c5d9091b4a577d6e511f9487b42L148-L151): Removed redundant docblocks from the `decryptAttributes` method.
* [`src/Traits/EncryptableDbAttribute.php`](diffhunk://#diff-991a58c19c5359b1298f712e10055ced99496c5d9091b4a577d6e511f9487b42L167-R183): Reformatted the `encrypt` and `decrypt` methods for better readability by adding braces to the catch blocks.

Closed prior PR for [Laravel 10 & 11 Support](https://github.com/betterapp/laravel-db-encrypter/pull/33) now that Laravel 12 has shipped and Laravel 10 has reached [EOS](https://laravel.com/docs/master/releases#support-policy).